### PR TITLE
Fixed createMainCopiedLog freezing by creating logFolder if needed

### DIFF
--- a/main.py
+++ b/main.py
@@ -1766,6 +1766,8 @@ class EzroApp:
 
     def createMainCopiedLog(self, currIndex, logType="Export"):
         currTime = datetime.now().isoformat(timespec='seconds').replace(":", ".")
+        if not path.exists(logFolder):
+            mkdir(logFolder)
         if len(self.romsCopied) + len(self.romsFailed) > 0:
             self.romsCopied.sort()
             self.romsFailed.sort()


### PR DESCRIPTION
This fixes createMainCopiedLog causing the program to get stuck if logFolder does not already exist.